### PR TITLE
adds news parameters to the initialize method on Le::Host::HTTP for loca...

### DIFF
--- a/lib/le.rb
+++ b/lib/le.rb
@@ -11,6 +11,8 @@ module Le
     opt_ssl       = options[:ssl]                       || false
     opt_tag       = options[:tag]                       || false
     opt_log_level = options[:log_level]                 || Logger::DEBUG
+    opt_local_shift_age = options[:local_shift_age]     || 0
+    opt_local_shift_size = options[:local_shift_size]   || 1048576
 
     opt_datahub_enabled = options[:datahub_enabled]     || false
     opt_datahub_endpoint = options[:datahub_endpoint]   || ['', 10000]
@@ -26,7 +28,7 @@ module Le
     self.checkParams(token, opt_datahub_enabled, opt_udp_port)
 
 
-    host = Le::Host.new(token, opt_local, opt_debug, opt_ssl, opt_datahub_endpoint, opt_host_id, opt_custom_host, opt_udp_port)
+    host = Le::Host.new(token, opt_local, opt_debug, opt_ssl, opt_datahub_endpoint, opt_host_id, opt_custom_host, opt_udp_port, opt_local_shift_age, opt_local_shift_size)
 
     if defined?(ActiveSupport::TaggedLogging) &&  opt_tag
       logger = ActiveSupport::TaggedLogging.new(Logger.new(host))
@@ -34,7 +36,7 @@ module Le
       logger = ActiveSupport::Logger.new(host)
       logger.formatter = host.formatter if host.respond_to?(:formatter)
     else
-      logger = Logger.new(host)
+      logger = Logger.new(host, opt_local_shift_age,opt_local_shift_size)
       logger.formatter = host.formatter if host.respond_to?(:formatter)
     end
 

--- a/lib/le/host.rb
+++ b/lib/le/host.rb
@@ -2,9 +2,9 @@ module Le
   module Host
 
 #!    def self.new(token, local, debug, ssl, datahub_enabled, datahub_ip, datahub_port, host_id, host_name_enabled, host_name)
-    def self.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port)
+    def self.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, local_shift_age, local_shift_size)
 
-      Le::Host::HTTP.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port)
+      Le::Host::HTTP.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, local_shift_age, local_shift_size)
     end
 
     module InstanceMethods

--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -21,7 +21,7 @@ module Le
       attr_accessor :token, :queue, :started, :thread, :conn, :local, :debug, :ssl, :datahub_enabled, :datahub_ip, :datahub_port, :datahub_endpoint, :host_id, :host_name_enabled, :host_name, :custom_host, :udp_port
 
 
-      def initialize(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port)
+      def initialize(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, local_shift_age, local_shift_size)
           if local
             device = if local.class <= TrueClass
               if defined?(Rails)
@@ -32,7 +32,7 @@ module Le
             else
             local
             end
-          @logger_console = Logger.new(device)
+          @logger_console = Logger.new(device, local_shift_age, local_shift_size)
           end
 
           @local = !!local

--- a/test/host_spec.rb
+++ b/test/host_spec.rb
@@ -11,9 +11,11 @@ describe Le::Host do
   let(:datahub_endpoint) { ["", 10000] }
   let(:host_id) { ""}
   let(:custom_host)	{ [false, ""]}
+  let(:local_shift_age) { 0 }
+  let(:local_shift_size) { 100000 }
 
   #let(:host)    { Le::Host.new(token, local, debug, ssl) }
-  let(:host)	{ Le::Host.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port)}
+  let(:host)	{ Le::Host.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, local_shift_age, local_shift_size)}
   specify { host.must_be_instance_of Le::Host::HTTP }
 
 end

--- a/test/http_spec.rb
+++ b/test/http_spec.rb
@@ -8,6 +8,8 @@ describe Le::Host::HTTP do
   let(:debug)              { false }
   let(:ssl)                { false }
   let(:udp)                { nil }
+  let(:local_shift_age)    { 0 }
+  let(:local_shift_size)   { 1000000 }
 
   let(:datahub_endpoint)  { ["", 10000]}
   let(:host_id)           {""}
@@ -15,7 +17,7 @@ describe Le::Host::HTTP do
 
 
 #  let(:host)               { Le::Host::HTTP.new(token, local, debug, ssl) }
-  let(:host)               { Le::Host::HTTP.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp) }
+  let(:host)               { Le::Host::HTTP.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, local_shift_age, local_shift_size) }
 
   let(:logger_console)     { host.instance_variable_get(:@logger_console) }
   let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }

--- a/test/le_spec.rb
+++ b/test/le_spec.rb
@@ -4,10 +4,15 @@ describe Le do
 
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:local)              { false }
-  let(:logger)             { Le.new(token, local: local) }
+  let(:local_shift_age)    { nil }
+  let(:local_shift_size)   { nil }
+
+  let(:logger)             { Le.new(token, local: local, local_shift_age: local_shift_age, local_shift_size: local_shift_size) }
   let(:logdev)             { logger.instance_variable_get(:@logdev).dev }
   let(:logger_console)     { logdev.instance_variable_get(:@logger_console) }
   let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
+  let(:logdev_shift_age)   { logger_console.instance_variable_get(:@logdev).instance_variable_get(:@shift_age) }
+  let(:logdev_shift_size)  { logger_console.instance_variable_get(:@logdev).instance_variable_get(:@shift_size) }
 
 
   describe "when non-Rails environment" do
@@ -66,6 +71,21 @@ describe Le do
         specify { logger_console.must_be_instance_of Logger }
         specify { logger_console_dev.must_be_instance_of File }
         specify { logger_console_dev.path.must_match 'local_log.log' }
+      end
+
+    end
+
+    describe "and :local_shift_age and :local_shift_size " do
+      let(:local_test_log) { Pathname.new(File.dirname(__FILE__)).join('fixtures','log','local_log.log') }
+      let(:log_file) { local_test_log.to_s }
+      let(:local)   { log_file }
+      let(:local_shift_age) { 1 }
+      let(:local_shift_size) { 100000 }
+
+      describe "local options" do
+
+        specify { logdev_shift_age.must_equal 1 }
+        specify { logdev_shift_size.must_equal 100000 }
       end
 
     end


### PR DESCRIPTION
...l_shift_age and local_shift_size. These parameters allow for the initialization of a local Logger class specifying the shift_age and shift_size params - which allow for local file log rotation. I believe you get this for free if you are using the Rails logger, but if you are using the standard ruby logger you do not. So I wanted to be able have the local logger init-ed by the Le::Host.new call pass these params