### PR TITLE
Add data.logentries.com endpoint

### DIFF
--- a/LE.gemspec
+++ b/LE.gemspec
@@ -5,7 +5,7 @@ require 'le'
 
 Gem::Specification.new do |gem|
   gem.name	= "le"
-  gem.version	= "2.6.2"
+  gem.version	= "2.7.0"
   gem.date	= Time.now
   gem.summary	= "Logentries plugin"
   gem.licenses    = ["MIT"]

--- a/lib/le.rb
+++ b/lib/le.rb
@@ -22,11 +22,12 @@ module Le
     opt_custom_host = options[:custom_host]             || [false, '']
 
     opt_udp_port = options[:udp_port]                   || nil
+    opt_use_data_endpoint = options[:data_endpoint]     || false
 
     self.checkParams(token, opt_datahub_enabled, opt_udp_port)
 
 
-    host = Le::Host.new(token, opt_local, opt_debug, opt_ssl, opt_datahub_endpoint, opt_host_id, opt_custom_host, opt_udp_port)
+    host = Le::Host.new(token, opt_local, opt_debug, opt_ssl, opt_datahub_endpoint, opt_host_id, opt_custom_host, opt_udp_port, opt_use_data_endpoint)
 
     if defined?(ActiveSupport::TaggedLogging) &&  opt_tag
       logger = ActiveSupport::TaggedLogging.new(Logger.new(host))


### PR DESCRIPTION
Allow for Users to use data.logentries.com endpoint instead of api.logentries.com.

The benefit here is that this endpoint allows connections over port 80 and 443. 

Currently making it an optional param as I am worried I will break folks integration if I change the currentd default endpoint. 

In other news I think the options list has become extremely bloated :( 