### PR TITLE
Remove pre-pending severity level in log entries

### DIFF
--- a/lib/le/host.rb
+++ b/lib/le/host.rb
@@ -17,7 +17,7 @@ module Le
       def format_message(message_in, severity)
         message_in = message_in.inspect unless message_in.is_a?(String)
 
-        "severity=#{severity}, #{message_in.lstrip}"
+        "#{message_in.lstrip}"
       end
     end
 


### PR DESCRIPTION
"severity={level}" is added to the beginning of the log by default, which causes JSON logs to be interpreted as KeyValue.